### PR TITLE
Feature: Make command feedback information toggleable #149

### DIFF
--- a/src/main/java/chikachi/discord/core/config/discord/CommandConfig.java
+++ b/src/main/java/chikachi/discord/core/config/discord/CommandConfig.java
@@ -27,6 +27,7 @@ public class CommandConfig {
     private String name;
     private String command;
     private boolean enabled;
+    private boolean outputEnabled;
     private List<String> aliases = new ArrayList<>();
     private List<String> permissions = new ArrayList<>();
 
@@ -34,10 +35,11 @@ public class CommandConfig {
 
     }
 
-    public CommandConfig(String name, String command, boolean enabled, List<String> aliases, List<String> permissions) {
+    public CommandConfig(String name, String command, boolean enabled,  boolean outputEnabled, List<String> aliases, List<String> permissions) {
         this.name = name;
         this.command = command;
         this.enabled = enabled;
+        this.outputEnabled = outputEnabled;
         this.aliases = aliases;
         this.permissions = permissions;
     }
@@ -48,6 +50,10 @@ public class CommandConfig {
 
     public boolean isEnabled() {
         return enabled;
+    }
+
+    public boolean isOutputEnabled() {
+        return outputEnabled;
     }
 
     public boolean shouldExecute(String command, User executor, MessageChannel channel) {

--- a/src/test/java/chikachi/discord/core/test/CommandTest.java
+++ b/src/test/java/chikachi/discord/core/test/CommandTest.java
@@ -38,7 +38,7 @@ public class CommandTest {
         permissions.add("user:" + permittedUserId);
         permissions.add("user:" + permittedUserName);
 
-        commandConfig = new CommandConfig("test", "test {ARG_1} {ARG_2} {ARGS}", true, aliases, permissions);
+        commandConfig = new CommandConfig("test", "test {ARG_1} {ARG_2} {ARGS}", true, true, aliases, permissions);
     }
 
     @Test


### PR DESCRIPTION
Issue: https://github.com/Chikachi/DiscordIntegration/issues/149

Allows us to set the outputEnabled flag to disable command output to the Discord console.
The value defaults to true.

This is one part of the commit, the DiscordIntegration PR https://github.com/Chikachi/DiscordIntegration/pull/151 is also required.